### PR TITLE
Turn on/off bashgit

### DIFF
--- a/.bashgit
+++ b/.bashgit
@@ -44,7 +44,7 @@ _bashgit_on() {
 _bashgit_update_PS1() {
     if [ "${_BASH_GIT_OFF}" = "true" ]; then
       # reset PS1
-      PS1=${PS1//"$_BASHGIT_PS1_PREV_PART"}
+      PS1=${PS1//" $_BASHGIT_PS1_PREV_PART"}
       return
     fi
     type git &>/dev/null || return 1

--- a/.bashgit
+++ b/.bashgit
@@ -33,20 +33,7 @@ declare _BASHGIT_PS1_PREV       # Previous PS1, may include injected bashgit sta
 declare _BASHGIT_PS1_PREV_PART  # Previously injected bashgit part in PS1 prompt
 declare _BASHGIT_CUR_BRANCH     # Current branch name
 
-_bashgit_off() {
-    _BASH_GIT_OFF=true
-}
-
-_bashgit_on() {
-    _BASH_GIT_OFF=
-}
-
 _bashgit_update_PS1() {
-    if [ "${_BASH_GIT_OFF}" = "true" ]; then
-      # reset PS1
-      PS1=${PS1//" $_BASHGIT_PS1_PREV_PART"}
-      return
-    fi
     type git &>/dev/null || return 1
 
     local         red='\[\e[0;31m\]'

--- a/.bashgit
+++ b/.bashgit
@@ -56,7 +56,7 @@ _bashgit_update_PS1() {
     [ "${-/f}" = "$-" ] && set -f || noglob_orig=1
     
     # User options
-    local untracked=true untracked_param=normal showremote=true branchlimit=22
+    local untracked=true untracked_param=normal showremote=true branchlimit=22 disabled=false
     for line in $(LC_MESSAGES=C git config --get-regexp '^bashgit\.' 2>/dev/null); do
         case $line in
             'bashgit.untracked '*) untracked=${line#* } ;;

--- a/.bashgit
+++ b/.bashgit
@@ -62,9 +62,19 @@ _bashgit_update_PS1() {
             'bashgit.untracked '*) untracked=${line#* } ;;
             'bashgit.branchlimit '*) branchlimit=${line#* } ;;
             'bashgit.showremote '*) showremote=${line#* } ;;
+            'bashgit.disabled '*) disabled=${line#* } ;;
         esac
     done
     [ "$untracked" = false ] && untracked_param=no
+
+    if [ "$disabled" = true ]; then
+        # bashgit is disabled, cancel prompt injection.
+        if [ "$_BASHGIT_PS1_ORIG" ]; then
+            PS1=$_BASHGIT_PS1_ORIG
+            _BASHGIT_PS1_PREV_PART=
+        fi
+        return 2
+    fi
 
     # Invoke git status and extract info
     for line in $(LC_MESSAGES=C git status --porcelain -bs -u${untracked_param} 2>/dev/null); do

--- a/.bashgit
+++ b/.bashgit
@@ -33,7 +33,20 @@ declare _BASHGIT_PS1_PREV       # Previous PS1, may include injected bashgit sta
 declare _BASHGIT_PS1_PREV_PART  # Previously injected bashgit part in PS1 prompt
 declare _BASHGIT_CUR_BRANCH     # Current branch name
 
+_bashgit_off() {
+    _BASH_GIT_OFF=true
+}
+
+_bashgit_on() {
+    _BASH_GIT_OFF=
+}
+
 _bashgit_update_PS1() {
+    if [ "${_BASH_GIT_OFF}" = "true" ]; then
+      # reset PS1
+      PS1=${PS1//"$_BASHGIT_PS1_PREV_PART"}
+      return
+    fi
     type git &>/dev/null || return 1
 
     local         red='\[\e[0;31m\]'


### PR DESCRIPTION
Hi,
I really enjoy bashgit, it is a really nice script.

This PR adds the ability to turn on or off bashgit.
When a git repo is huge (like [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)), getting the git status takes a long time. I find it useful to be able to turn it off without editing + sourcing the `.bashrc`.